### PR TITLE
[TCE-169][TCE-172] Upgrade prod sql database to zone-redundant S6 tier

### DIFF
--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -51,4 +51,5 @@ app_plan_sku_name = "P0v3"
 #
 # azure sql
 #
-sql_database_sku_name = "S0"
+sql_database_sku_name    = "S6"
+sql_database_max_size_gb = 1024


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The database capacity is not yet determined.
Also, DTU model tiers (S vs P) are difficult to compare as IOPS in Premium are much higher.

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
