### PR TITLE
feat: GitHub self hosted runner Container Apps job

### DIFF
--- a/src/core/.terraform.lock.hcl
+++ b/src/core/.terraform.lock.hcl
@@ -1,6 +1,26 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/azure/azapi" {
+  version     = "1.14.0"
+  constraints = "~> 1.12"
+  hashes = [
+    "h1:D8AhiIgpSH6pG05WuslOg3XS0O9I5VxOoD3W3i8N+Xo=",
+    "zh:083709be750b878dfb33747ba1d326d23619a0ed654f95bce9c808e424923c90",
+    "zh:261b5060297b732d97b4363ad753355bfee00e93d773fd329023a5619b964c39",
+    "zh:51adfdaeb1b2c3d9e7aeba97c9c73d469712223dd125b14d90377d445d1cd3df",
+    "zh:5bcbedc9eeefa5e6267042604af20f93cadceba41d8d90a91040f60f6c5e38a9",
+    "zh:6da127f306083e740767f53dd0cc8787166a8af4f44519873dd8775ca981ddef",
+    "zh:7604cf377b8ea31a5a44db5b8566f5eea4d73acdfaaeb8ba10fcac46cbf4a738",
+    "zh:77789ef8906acabbf7eb55378e1f9c407499bb765811f193d256897d2925d66d",
+    "zh:8a333c53279b3b0b65519191dbba8ef7dc390f5d96216e4e6f165cac8b3e5dc2",
+    "zh:8c0dfe57dc2c29f8953db3037144d2254ce28bfa55dae537707ae4bdb4460f64",
+    "zh:debdeabcbcb6b421c2cdf2093d520c67e75a11d28d357b0ba32dd748105a5460",
+    "zh:e252ee062513904836fcc5e6548243429819e68aa7cfaeac7da8d816c4c4d1e8",
+    "zh:f48d1fd67b463d2121516911b5d20f8a72217e43e7740bb74929a17dbd43bb59",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azuread" {
   version     = "2.43.0"
   constraints = "<= 2.43.0"

--- a/src/core/40_gh_self_hosted_runner.tf
+++ b/src/core/40_gh_self_hosted_runner.tf
@@ -1,0 +1,96 @@
+
+variable "self_hosted_runner_github_repos" {
+  type = list(object({
+    name                 = optional(string)
+    repo_owner           = optional(string)
+    repo                 = optional(string)
+    polling_interval     = optional(number)
+    scale_max_executions = optional(number)
+  }))
+
+  default = [
+    {
+      name                 = "pf-be" // portale-fatturazione-be will make the job name exceed 32 chars
+      repo_owner           = "pagopa"
+      repo                 = "portale-fatturazione-be"
+      polling_interval     = 30
+      scale_max_executions = 5
+    },
+  ]
+
+  description = "Container App job properties for GitHub self-hosted runners"
+}
+
+locals {
+  gh_runner = {
+    rg_name          = "${local.project}-github-runner-rg"
+    law_name         = "${local.project}-runner-law"
+    environment_name = "${local.project}-runner-cae"
+  }
+}
+
+resource "azurerm_resource_group" "runner_rg" {
+  name     = local.gh_runner.rg_name
+  location = var.location
+
+  tags = var.tags
+}
+
+resource "azurerm_log_analytics_workspace" "runner_law" {
+  name                = local.gh_runner.law_name
+  location            = azurerm_resource_group.runner_rg.location
+  resource_group_name = azurerm_resource_group.runner_rg.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+
+  tags = var.tags
+}
+
+module "github_runner_snet" {
+  source                                    = "./.terraform/modules/__v3__/subnet/"
+  name                                      = format("%s-%s-snet", local.project, "github-runner")
+  address_prefixes                          = var.cidr_github_runner_snet
+  resource_group_name                       = azurerm_resource_group.networking.name
+  virtual_network_name                      = module.vnet.name
+  private_endpoint_network_policies_enabled = false
+  service_endpoints                         = []
+}
+
+resource "azurerm_container_app_environment" "runner_cae" {
+  name                           = local.gh_runner.environment_name
+  resource_group_name            = azurerm_resource_group.runner_rg.name
+  location                       = azurerm_resource_group.runner_rg.location
+  log_analytics_workspace_id     = azurerm_log_analytics_workspace.runner_law.id
+  infrastructure_subnet_id       = module.github_runner_snet.id
+  internal_load_balancer_enabled = true
+
+  tags = var.tags
+}
+
+module "container_app_job_runner" {
+  for_each = { for job in var.self_hosted_runner_github_repos : job.name => job }
+  source   = "./.terraform/modules/__v3__8_28_2__/container_app_job_gh_runner/"
+
+  location  = var.location
+  prefix    = var.prefix
+  env_short = var.env_short
+
+  # sets reference to the secret which holds the GitHub PAT with access to your repos
+  key_vault = {
+    resource_group_name = module.key_vault.resource_group_name
+    name                = module.key_vault.name
+    # TODO name
+    secret_name = "github-bot-cicd"
+  }
+
+  # sets reference to the log analytics workspace you want to use for logging
+  environment = {
+    name                = azurerm_container_app_environment.runner_cae.name
+    resource_group_name = azurerm_container_app_environment.runner_cae.resource_group_name
+  }
+
+  # sets job properties
+  job = each.value
+
+  tags = var.tags
+}

--- a/src/core/99_main.tf
+++ b/src/core/99_main.tf
@@ -31,6 +31,12 @@ module "__v3__" {
   source = "git::https://github.com/pagopa/terraform-azurerm-v3.git?ref=d97d51148b02eb3225507eeef2ec25d52f4f343b"
 }
 
+// add recent version for smooth and gradual migration
+module "__v3__8_28_2__" {
+  # https://github.com/pagopa/terraform-azurerm-v3/releases/tag/v8.28.2
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git?ref=4d6f6c0e95493ae12458dd1dbf643a27328e2383"
+}
+
 data "azurerm_subscription" "current" {}
 
 data "azurerm_client_config" "current" {}

--- a/src/core/99_variables.tf
+++ b/src/core/99_variables.tf
@@ -132,6 +132,11 @@ variable "cidr_dns_fwd_snet" {
   description = "cidr of the dns forwarder subnet"
 }
 
+variable "cidr_github_runner_snet" {
+  type        = list(string)
+  description = "cidr of the github runner subnet"
+}
+
 #
 # secondary networking
 #

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -22,14 +22,15 @@ dns_zone_portalefatturazione_prefix = "portalefatturazione"
 #
 # networking
 #
-cidr_vnet          = ["10.0.0.0/18"]
-cidr_agw_snet      = ["10.0.0.0/24"]
-cidr_app_snet      = ["10.0.1.0/24"]
-cidr_synapse_snet  = ["10.0.2.0/24"]
-cidr_hsql_snet     = ["10.0.3.0/24"]
-cidr_pvt_endp_snet = ["10.0.60.0/23"]
-cidr_dns_fwd_snet  = ["10.0.62.248/29"] # we want 3 IPs only on this subnet (5 are reserved by Azure)
-cidr_vpn_snet      = ["10.0.63.0/24"]
+cidr_vnet               = ["10.0.0.0/18"]
+cidr_agw_snet           = ["10.0.0.0/24"]
+cidr_app_snet           = ["10.0.1.0/24"]
+cidr_synapse_snet       = ["10.0.2.0/24"]
+cidr_hsql_snet          = ["10.0.3.0/24"]
+cidr_github_runner_snet = ["10.0.58.0/23"]
+cidr_pvt_endp_snet      = ["10.0.60.0/23"]
+cidr_dns_fwd_snet       = ["10.0.62.248/29"] # we want 3 IPs only on this subnet (5 are reserved by Azure)
+cidr_vpn_snet           = ["10.0.63.0/24"]
 
 #
 # secondary networking


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Add a Container Apps Job to be used as GitHub self hosted runner.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

The CI/CD pipeline (still to be implemented) of the [portale-fatturazione-be](https://github.com/pagopa/portale-fatturazione-infra) needs to access resources private in the Portale Fatturazione network.
This can be accomplished with a GitHub self hosted runner that runs in the same vnet as the Portale Fatturazione backend. As per policy and PagoPA best practice, a Container Apps job is used, provisioned by the PagoPA dedicated module [container_app_job_gh_runner](https://github.com/pagopa/terraform-azurerm-v3/tree/main/container_app_job_gh_runner).

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
