### PR TITLE
feat: Add managed identity for CI/CD

### DIFF
--- a/.identity/04_azure_appservice_cd.tf
+++ b/.identity/04_azure_appservice_cd.tf
@@ -1,0 +1,59 @@
+
+// TODO here a "convention over configuration" is used on naming, but some of these should be vars!
+// TODO should this be put directly into portal-fatturazione-be repo?
+
+data "azurerm_resource_group" "identity_rg" {
+  name = "${local.project}-identity-rg"
+}
+
+data "azurerm_resource_group" "app_rg" {
+  name = "${local.project}-app-rg"
+}
+
+data "azurerm_linux_web_app" "app_api" {
+  # TODO swap container
+  name                = "${local.project}-app-api-container"
+  resource_group_name = data.azurerm_resource_group.app_rg.name
+}
+
+resource "azurerm_user_assigned_identity" "backend_cd" {
+  resource_group_name = data.azurerm_resource_group.identity_rg.name
+  location            = data.azurerm_resource_group.identity_rg.location
+  name                = "${local.project}-be-cd"
+}
+
+resource "azurerm_role_assignment" "app_backend_contributor" {
+  scope                = data.azurerm_resource_group.app_rg.id
+  role_definition_name = "Contributor"
+  principal_id         = azurerm_user_assigned_identity.backend_cd.principal_id
+}
+
+resource "azurerm_federated_identity_credential" "backend_cd" {
+  parent_id           = azurerm_user_assigned_identity.backend_cd.id
+  name                = "github-federated"
+  resource_group_name = data.azurerm_resource_group.identity_rg.name
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = "https://token.actions.githubusercontent.com"
+  subject             = "repo:${var.github.org}/portale-fatturazione-be:environment:${var.env}"
+}
+
+# add role assignment to default roleassignment rg:
+# the managed identity needs at least reader on one rg (or the whole subscription)
+
+data "azurerm_resource_group" "default_assignment_rg" {
+  name = "default-roleassignment-rg"
+}
+
+resource "azurerm_role_assignment" "managed_identity_default_role_assignment" {
+  scope                = data.azurerm_resource_group.default_assignment_rg.id
+  role_definition_name = "Reader"
+  principal_id         = azurerm_user_assigned_identity.backend_cd.principal_id
+}
+
+output "id_backend_cd" {
+  value = {
+    id           = azurerm_user_assigned_identity.backend_cd.id
+    principal_id = azurerm_user_assigned_identity.backend_cd.principal_id
+    client_id    = azurerm_user_assigned_identity.backend_cd.client_id
+  }
+}

--- a/.identity/env/prod/terraform.tfvars
+++ b/.identity/env/prod/terraform.tfvars
@@ -1,4 +1,4 @@
-prefix    = "product"
+prefix    = "fat"
 env_short = "p"
 env       = "prod"
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

> ⚠️ Do not merge this. this PR is here to track IaC code for managed identity for CI/CD in portale-fatturazione-be, but it is correct here or it should be included in the portale-fatturazione-be directly, also managing from IaC the GitHub environment and secrets?

### List of changes

<!--- Describe your changes in detail -->
Add managed identity for GitHub CI/CD with OIDC federation from portale-fatturazione-be.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
We need it for enabling GitHub workflow in prod environment to deploy the app service

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
