### PR TITLE
feat: Add variables for on-demand invoices and report assessment

### DIFF
--- a/src/core/20_appservice.tf
+++ b/src/core/20_appservice.tf
@@ -182,9 +182,9 @@ resource "azurerm_linux_web_app" "app_api" {
   tags = var.tags
 }
 
-resource "azurerm_role_assignment" "api_synapse_user" {
-  scope                = azurerm_synapse_workspace.this.id
-  role_definition_name = "Synapse User"
+resource "azurerm_synapse_role_assignment" "api_synapse_user" {
+  synapse_workspace_id = azurerm_synapse_workspace.this.id
+  role_name            = "Synapse User"
   principal_id         = azurerm_linux_web_app.app_api.identity[0].principal_id
 }
 

--- a/src/core/20_appservice.tf
+++ b/src/core/20_appservice.tf
@@ -126,6 +126,13 @@ resource "azurerm_linux_web_app" "app_api" {
     AZUREAD_ADGROUP          = "fat-${var.env_short}-adgroup-"
     STORAGE_CONNECTIONSTRING = "@Microsoft.KeyVault(VaultName=${module.key_vault_app.name};SecretName=RelStorageConnectionString)"
     STORAGE_REL_FOLDER       = "rel"
+
+    STORAGE_DOCUMENTI_CONNECTIONSTRING = "@Microsoft.KeyVault(VaultName=${module.key_vault_app.name};SecretName=DlsStorageConnectionString)"
+    STORAGE_DOCUMENTI_FOLDER           = "reportaccertamenti"
+    SYNAPSE_WORKSPACE_NAME             = azurerm_synapse_workspace.this.name
+    PIPELINE_NAME_SAP                  = "SendJsonToSap",
+    SYNAPSE_SUBSCRIPTIONID             = data.azurerm_client_config.current.subscription_id
+    SYNAPSE_RESOURCEGROUPNAME          = azurerm_synapse_workspace.this.resource_group_name
   }
 
   site_config {
@@ -173,6 +180,12 @@ resource "azurerm_linux_web_app" "app_api" {
     ]
   }
   tags = var.tags
+}
+
+resource "azurerm_role_assignment" "api_synapse_user" {
+  scope                = azurerm_synapse_workspace.this.id
+  role_definition_name = "Synapse User"
+  principal_id         = azurerm_linux_web_app.app_api.identity[0].principal_id
 }
 
 # vnet integration

--- a/src/core/20_storage.tf
+++ b/src/core/20_storage.tf
@@ -31,6 +31,14 @@ resource "azurerm_storage_container" "dls_synapse" {
   container_access_type = "private"
 }
 
+#tfsec:ignore:azure-keyvault-content-type-for-secret
+#tfsec:ignore:azure-keyvault-ensure-secret-expiry
+resource "azurerm_key_vault_secret" "dls_storage_connection_string" {
+  name         = "DlsStorageConnectionString"
+  value        = module.dls_storage.primary_connection_string
+  key_vault_id = module.key_vault_app.id
+}
+
 #
 # sa storage
 #


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- Add key vault secret for `fatpdls` storage account connection string
- Add variables to web app `fat-p-app-api` for connection to `fatpdls` storage account
- Add variables to web app `fat-p-app-api` for invoking Synapse pipeline
- Add role assignment to web app `fat-p-app-api` managed identity for allowing invocation of Synapse pipeline

### Motivation and context

Allow on-demand invoices and report assessment.

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
