### PR TITLE
feat(core): Add storage account for download invoices

### DIFF
--- a/src/core/20_appservice.tf
+++ b/src/core/20_appservice.tf
@@ -133,6 +133,10 @@ resource "azurerm_linux_web_app" "app_api" {
     PIPELINE_NAME_SAP                  = "SendJsonToSap",
     SYNAPSE_SUBSCRIPTIONID             = data.azurerm_client_config.current.subscription_id
     SYNAPSE_RESOURCEGROUPNAME          = azurerm_synapse_workspace.this.resource_group_name
+
+    STORAGE_FINANCIAL_ACCOUNTNAME   = module.public_storage.name
+    STORAGE_FINANCIAL_ACCOUNTKEY    = "@Microsoft.KeyVault(VaultName=${module.key_vault_app.name};SecretName=PublicStorageKey)"
+    STORAGE_FINANCIAL_CONTAINERNAME = "invoices"
   }
 
   site_config {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- Add storage account with public endpoint enabled
- Add key vault secret with storage account access key
- Add env variables to the app for connection to the storage account

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Allow public download of invoices with SAS token.

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
