### PR TITLE
feat: [PFI-1] Allow synapse to access public storage account

### DIFF
--- a/src/core/20_synapse.tf
+++ b/src/core/20_synapse.tf
@@ -69,6 +69,12 @@ resource "azurerm_role_assignment" "synw_sap_storage_blob_data_contributor" {
   principal_id         = azurerm_synapse_workspace.this.identity[0].principal_id
 }
 
+resource "azurerm_role_assignment" "synw_public_storage_blob_data_contributor" {
+  scope                = module.public_storage.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_synapse_workspace.this.identity[0].principal_id
+}
+
 # integration runtime
 resource "azurerm_synapse_integration_runtime_azure" "this" {
   name                 = format("%s-%s", local.project, "synw-integration-runtime")
@@ -317,4 +323,12 @@ resource "azurerm_synapse_managed_private_endpoint" "sendemail" {
   synapse_workspace_id = azurerm_synapse_workspace.this.id
   target_resource_id   = azurerm_linux_function_app.send_email.id
   subresource_name     = "sites"
+}
+
+# managed_private_endpoint must be manual approved on target resource
+resource "azurerm_synapse_managed_private_endpoint" "public_storage" {
+  name                 = format("%s-public-storage-endpoint", azurerm_synapse_workspace.this.name)
+  synapse_workspace_id = azurerm_synapse_workspace.this.id
+  target_resource_id   = module.public_storage.id
+  subresource_name     = "blob"
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- Synapse managed private endpoint to the "public" storage account
- Synapse "public" storage account blob contributor

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Synapse needs to access "public" storage account

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
