### PR TITLE
fix: [PFI-6] Access backend app only through private endpoint

### DIFF
--- a/src/core/10_appgateway.tf
+++ b/src/core/10_appgateway.tf
@@ -96,7 +96,7 @@ module "agw" {
   listeners = {
     api = {
       protocol           = "Https"
-      host               = join(".", [var.dns_api_prefix, var.dns_zone_portalefatturazione_prefix, var.dns_external_domain])
+      host               = local.fqdn_api
       port               = 443
       ssl_profile_name   = null
       firewall_policy_id = null
@@ -111,7 +111,7 @@ module "agw" {
     }
     apex = {
       protocol           = "Https"
-      host               = join(".", [var.dns_zone_portalefatturazione_prefix, var.dns_external_domain])
+      host               = local.fqdn_fe
       port               = 443
       ssl_profile_name   = null
       firewall_policy_id = null

--- a/src/core/20_appservice.tf
+++ b/src/core/20_appservice.tf
@@ -9,8 +9,8 @@ locals {
       CONNECTION_STRING                   = "@Microsoft.KeyVault(VaultName=${module.key_vault_app.name};SecretName=ConnectionString)"
       JWT_SECRET                          = "@Microsoft.KeyVault(VaultName=${module.key_vault_app.name};SecretName=JwtSecret)"
       ADMIN_KEY                           = "@Microsoft.KeyVault(VaultName=${module.key_vault_app.name};SecretName=AdminKey)"
-      JWT_VALID_AUDIENCE                  = "${format("%s-%s", local.project, "app-api")}.azurewebsites.net"
-      JWT_VALID_ISSUER                    = "${format("%s-%s", local.project, "app-api")}.azurewebsites.net"
+      JWT_VALID_AUDIENCE                  = local.fqdn_api
+      JWT_VALID_ISSUER                    = local.fqdn_api
       KEY_VAULT_NAME                      = module.key_vault_app.name
       SELFCARE_CERT_ENDPOINT              = "/.well-known/jwks.json"
       SELF_CARE_URI                       = var.app_api_config_selfcare_url
@@ -166,13 +166,14 @@ locals {
 
 # api
 resource "azurerm_linux_web_app" "app_api" {
-  name                       = format("%s-%s", local.project, "app-api")
-  location                   = azurerm_resource_group.app.location
-  resource_group_name        = azurerm_resource_group.app.name
-  service_plan_id            = azurerm_service_plan.app.id
-  client_certificate_enabled = false
-  https_only                 = true
-  client_affinity_enabled    = false
+  name                          = format("%s-%s", local.project, "app-api")
+  location                      = azurerm_resource_group.app.location
+  resource_group_name           = azurerm_resource_group.app.name
+  service_plan_id               = azurerm_service_plan.app.id
+  client_certificate_enabled    = false
+  https_only                    = true
+  client_affinity_enabled       = false
+  public_network_access_enabled = false
 
   app_settings = local.app_api.app_settings
 
@@ -274,7 +275,7 @@ resource "azurerm_linux_web_app_slot" "app_api_staging" {
   client_certificate_enabled    = false
   https_only                    = true
   client_affinity_enabled       = false
-  public_network_access_enabled = true
+  public_network_access_enabled = false
 
   app_settings = local.app_api.app_settings
 

--- a/src/core/99_locals.tf
+++ b/src/core/99_locals.tf
@@ -1,3 +1,5 @@
 locals {
-  project = "${var.prefix}-${var.env_short}"
+  project  = "${var.prefix}-${var.env_short}"
+  fqdn_api = join(".", [var.dns_api_prefix, var.dns_zone_portalefatturazione_prefix, var.dns_external_domain])
+  fqdn_fe  = join(".", [var.dns_zone_portalefatturazione_prefix, var.dns_external_domain])
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- Private backend app and backend staging slot access
- Traffic will pass through gateway, modify JWT issuer and audience accordingly

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Improve security by having all API requests pass through application gateway with WAF.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
