### PR TITLE
feat: [PFI-12] Private link to CRM data lake for Synapse

### DIFF
--- a/src/core/20_synapse.tf
+++ b/src/core/20_synapse.tf
@@ -335,3 +335,14 @@ resource "azurerm_synapse_managed_private_endpoint" "public_storage" {
   target_resource_id   = module.public_storage.id
   subresource_name     = "blob"
 }
+
+# private endpoint for a CRM data lake EXTERNAL to this subscription,
+# we reference it directly by its id
+resource "azurerm_synapse_managed_private_endpoint" "crm_storage_dfs" {
+  count = var.crm_storage_id != null ? 1 : 0
+
+  name                 = format("%s-crm-storage-dfs-endpoint", azurerm_synapse_workspace.this.name)
+  synapse_workspace_id = azurerm_synapse_workspace.this.id
+  target_resource_id   = var.crm_storage_id
+  subresource_name     = "dfs"
+}

--- a/src/core/99_variables.tf
+++ b/src/core/99_variables.tf
@@ -237,6 +237,13 @@ variable "storage_sap_rule_ips" {
   default     = []
 }
 
+# this storage is in another subscription, we reference it directly by id
+variable "crm_storage_id" {
+  type        = string
+  description = "id of the CRM storage, that lies in another subscription"
+  default     = null
+}
+
 #
 # azure sql
 #

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -87,3 +87,5 @@ storage_sap_rule_ips = [
   "93.63.219.230",
   "93.63.219.234",
 ]
+
+crm_storage_id = "/subscriptions/59f48fac-dfdb-4063-bcc6-9322c9e5ebd0/resourceGroups/crm-p-data-rg/providers/Microsoft.Storage/storageAccounts/crmpdatast"

--- a/src/core/env/uat/terraform.tfvars
+++ b/src/core/env/uat/terraform.tfvars
@@ -86,3 +86,5 @@ storage_sap_rule_ips = [
   "93.42.64.143",
   "93.63.219.230",
 ]
+
+crm_storage_id = "/subscriptions/57cfa745-48f4-4ad8-91ab-fb63aebc57ec/resourceGroups/crm-u-data-rg/providers/Microsoft.Storage/storageAccounts/crmudatast"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Add Synapse private link to external storage account of CRM.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Be able to write to CRM storage account from Synapse with data exfiltration protection enabled.

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
