### PR TITLE
feat: [PFI-16] Increase app gateway timeout

### DIFF
--- a/src/core/10_appgateway.tf
+++ b/src/core/10_appgateway.tf
@@ -77,7 +77,7 @@ module "agw" {
       fqdns                       = [format("%s-%s.%s", local.project, "app-api", "azurewebsites.net")]
       probe                       = "/health"
       probe_name                  = "probe-app_api"
-      request_timeout             = 60
+      request_timeout             = 300
       pick_host_name_from_backend = false # module quirk
     },
     app_fe = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- Increase gateway timeout to 5 minutes for the API endpoint.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Temporary workaround for large file download.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
