### PR TITLE
feat: [PFI-21] Add auto ACME cert renewal on storage domains

### DIFF
--- a/src/azuredevops/env/prod/terraform.tfvars
+++ b/src/azuredevops/env/prod/terraform.tfvars
@@ -22,6 +22,10 @@ domains = [
     dns_zone_name   = "portalefatturazione.pagopa.it"
     dns_record_name = "api"
   },
+  {
+    dns_zone_name   = "portalefatturazione.pagopa.it"
+    dns_record_name = "storage"
+  },
 ]
 
 # pipeline for syncing azdo repo to github 

--- a/src/azuredevops/env/uat/terraform.tfvars
+++ b/src/azuredevops/env/uat/terraform.tfvars
@@ -22,4 +22,8 @@ domains = [
     dns_zone_name   = "uat.portalefatturazione.pagopa.it"
     dns_record_name = "api"
   },
+  {
+    dns_zone_name   = "uat.portalefatturazione.pagopa.it"
+    dns_record_name = "storage"
+  },
 ]


### PR DESCRIPTION
-------

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- Add Azure DevOps pipeline for TLS cert renewal with ACME for `storage<.env>.portalefatturazione.pagopa.it` domains.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Provide a TLS certificate for said domains with auto-renewal enabled.

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->